### PR TITLE
graceful shutdown, close SSE connections

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "node": ">=16"
   },
   "description": "GrowthBook proxy server for caching, realtime updates, telemetry, etc",
-  "version": "1.0.14",
+  "version": "1.0.15",
   "main": "dist/app.js",
   "license": "MIT",
   "repository": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,5 @@
 import init from "./init";
-import { Context, GrowthBookProxy, growthBookProxy } from "./app";
-import logger from "./services/logger";
+import { GrowthBookProxy, growthBookProxy } from "./app";
 
 // Sample implementation for the GrowthBookProxy
 (async () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,19 +1,29 @@
 import init from "./init";
-import { growthBookProxy } from "./app";
+import { Context, GrowthBookProxy, growthBookProxy } from "./app";
+import logger from "./services/logger";
 
 // Sample implementation for the GrowthBookProxy
 (async () => {
   const { app, server, context } = await init();
 
   // creating and starting the proxy is a one-liner
-  await growthBookProxy(app, context);
+  const proxy = await growthBookProxy(app, context);
 
   process.on("SIGTERM", () => {
     console.info("SIGTERM signal received: closing HTTP server");
-    // Todo: perform any cleanup
-    server.close(() => {
-      console.info("HTTP server closed");
-      process.exit(0);
-    });
+    onClose(server, proxy);
+  });
+  process.on("SIGINT", () => {
+    console.info("SIGINT signal received: closing HTTP server");
+    onClose(server, proxy);
   });
 })();
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+function onClose(server: any, proxy: GrowthBookProxy) {
+  proxy.services.eventStreamManager?.closeAll();
+  server.close(() => {
+    console.info("HTTP server closed");
+    process.exit(0);
+  });
+}

--- a/src/services/eventStreamManager/index.ts
+++ b/src/services/eventStreamManager/index.ts
@@ -97,6 +97,12 @@ export class SSEManager {
     this.appContext?.verboseDebugging && logger.info("No scoped channel found");
   }
 
+  public closeAll() {
+    this.scopedChannels.forEach((scopedChannel) => {
+      scopedChannel.channel.close();
+    });
+  }
+
   private getScopedChannel(apiKey: string): ScopedChannel | undefined {
     let scopedChannel = this.scopedChannels.get(apiKey);
     if (!scopedChannel) {

--- a/src/services/eventStreamManager/ssePubsub.ts
+++ b/src/services/eventStreamManager/ssePubsub.ts
@@ -72,7 +72,7 @@ export class SSEChannel {
   }
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  publish(data?: any, eventName?: string) {
+  public publish(data?: any, eventName?: string) {
     this.appContext?.verboseDebugging &&
       logger.info(
         { eventName: eventName || "[ping]", clients: this.clients.size },
@@ -124,7 +124,7 @@ export class SSEChannel {
     return id;
   }
 
-  subscribe(req: Request, res: Response, events?: (string | RegExp)[]) {
+  public subscribe(req: Request, res: Response, events?: (string | RegExp)[]) {
     this.appContext?.verboseDebugging &&
       logger.info("ssePubsub.subscribe: subscribe");
     if (!this.active) {
@@ -188,13 +188,13 @@ export class SSEChannel {
     return c;
   }
 
-  unsubscribe(c: Connection) {
+  public unsubscribe(c: Connection) {
     this.appContext?.verboseDebugging && logger.info("ssePubsub.unsubscribe");
     c.res.end();
     this.clients.delete(c);
   }
 
-  close() {
+  public close() {
     this.clients.forEach((c) => c.res.end());
     this.clients = new Set();
     this.messages = [];
@@ -202,7 +202,7 @@ export class SSEChannel {
     this.active = false;
   }
 
-  listClients() {
+  public listClients() {
     const rollupByIP: Record<string, number> = {};
     this.clients.forEach((c) => {
       const ip = c.req?.connection?.remoteAddress
@@ -216,7 +216,7 @@ export class SSEChannel {
     return rollupByIP;
   }
 
-  getSubscriberCount() {
+  public getSubscriberCount() {
     return this.clients.size;
   }
 


### PR DESCRIPTION
Prevents SSE connection error (and browser connection dropping) if your proxy server instance is able to receive SIGINT or SIGKILL events (SIGINT preferred).