### PR TITLE
feat: add an env var to set the express payload size limit

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ The GrowthBook Proxy supports a number of configuration options available via en
 - `GROWTHBOOK_API_HOST` - Set this to the host and port of your GrowthBook API instance
 - `SECRET_API_KEY` - Create a secret API key in GrowthBook by going to **Settings -> API Keys**
 - `NODE_ENV` - Set to "production" to hide debug and informational log messages
+- `PAYLOAD_SIZE_LIMIT` - Set the payload size limit of the express server. Default: 50mb
 
 ### Caching
 By default, features are cached in memory in GrowthBook Proxy; you may provide your own cache service via Redis or Mongo. To fully utilize the GrowthBook Proxy, we highly recommend using Redis, which is a prerequisite for real-time updates when your proxy is horizontally scaled (as proxy instances are kept in-sync using Redis pub/sub).

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "node": ">=16"
   },
   "description": "GrowthBook proxy server for caching, realtime updates, telemetry, etc",
-  "version": "1.0.19",
+  "version": "1.0.20",
   "main": "dist/app.js",
   "license": "MIT",
   "repository": {

--- a/src/controllers/featuresController.ts
+++ b/src/controllers/featuresController.ts
@@ -80,10 +80,6 @@ featuresRouter.get(
 featuresRouter.post(
   "/proxy/features",
   apiKeyMiddleware,
-  express.json({
-    verify: (req: Request, res: Response, buf: Buffer) =>
-      (res.locals.rawBody = buf),
-  }),
   webhookVerificationMiddleware,
   reencryptionMiddleware,
   broadcastEventStreamMiddleware,

--- a/src/init.ts
+++ b/src/init.ts
@@ -1,4 +1,4 @@
-import express from "express";
+import express, {Request, Response} from "express";
 import * as spdy from "spdy";
 import dotenv from "dotenv";
 import { CacheEngine, Context } from "./types";
@@ -60,6 +60,7 @@ export default async () => {
   const USE_HTTP2 = process.env.USE_HTTP2;
   const HTTPS_CERT = process.env.HTTPS_CERT;
   const HTTPS_KEY = process.env.HTTPS_KEY;
+  const PAYLOAD_SIZE_LIMIT = process.env.PAYLOAD_SIZE_LIMIT || "50mb";
 
   function getPort() {
     if (process.env.PORT) {
@@ -74,6 +75,14 @@ export default async () => {
 
   // Start Express
   const app = express();
+
+  app.use(express.json({
+    limit: PAYLOAD_SIZE_LIMIT,
+    verify: (req: Request, res: Response, buf) => {
+      res.locals.rawBody = buf
+    }
+  }));
+  
   /* eslint-disable @typescript-eslint/no-explicit-any */
   let server: any = null;
 


### PR DESCRIPTION
## Objectives
- To have an environment variable to control the express payload size limit.

## Proposed changes
- Implement the env var PAYLOAD_SIZE_LIMIT
- Centralize the `express.json` configs to `init.ts`
- Bump version
- Update readme

This PR solves issue #26.