### PR TITLE
Option to bypass SSL certificate verification

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 The GrowthBook Proxy server sits between your application and GrowthBook. It turbocharges your GrowthBook implementation by providing **speed**, **scalability**, **security**, and **real-time** feature rollouts.
 
 ### Features:
+
 - :zap: **Caching** - Significantly faster feature lookups!
   - In-memory cache plus an optional distributed layer (Redis or MongoDB)
   - Automatic cache invalidation when features change in GrowthBook (using WebHooks)
@@ -34,7 +35,9 @@ docker run -d -p 3300:3300 \
 Then, simply point your GrowthBook SDKs to the GrowthBook Proxy instead of the GrowthBook API.
 
 ### Self-hosted customers
+
 You will also need to ensure that your self-hosted GrowthBook instance is configured to use the proxy server. This includes setting environment variables:
+
 ```
 PROXY_ENABLED=1
 PROXY_HOST_PUBLIC=https://proxy.example.com
@@ -42,11 +45,12 @@ PROXY_HOST_PUBLIC=https://proxy.example.com
 ## Optional; you may also use the GrowthBook UI to set this:
 SECRET_API_KEY=something_secret
 ```
+
 See GrowthBook's [Proxy documentation](https://docs.growthbook.io/self-host/proxy#standalone) for more information.
 
 ### Cloud customers
-For GrowthBook Cloud customers, use the GrowthBook app UI to create an API key in **Settings -> API Keys**. Additionally, you will need to set proxy's `GROWTHBOOK_API_HOST` environment variable to the cloud API server: `https://api.growthbook.io`.
 
+For GrowthBook Cloud customers, use the GrowthBook app UI to create an API key in **Settings -> API Keys**. Additionally, you will need to set proxy's `GROWTHBOOK_API_HOST` environment variable to the cloud API server: `https://api.growthbook.io`.
 
 ## Configuration
 
@@ -57,6 +61,7 @@ The GrowthBook Proxy supports a number of configuration options available via en
 - `NODE_ENV` - Set to "production" to hide debug and informational log messages
 
 ### Caching
+
 By default, features are cached in memory in GrowthBook Proxy; you may provide your own cache service via Redis or Mongo. To fully utilize the GrowthBook Proxy, we highly recommend using Redis, which is a prerequisite for real-time updates when your proxy is horizontally scaled (as proxy instances are kept in-sync using Redis pub/sub).
 
 - `CACHE_ENGINE` - One of: `memory`, `redis`, or `mongo`
@@ -65,26 +70,27 @@ By default, features are cached in memory in GrowthBook Proxy; you may provide y
 - `CACHE_EXPIRES_TTL` - Number of seconds until a cache entry is expired (default is `600` = 10 minutes)
 
 #### Redis Cluster
+
 Redis-specific options for cluster mode:<br />
 _(Note that CACHE_CONNECTION_URL is ignored when using cluster mode)_
+
 - `USE_CLUSTER` - "true" or "1" to enable
 - `CLUSTER_ROOT_NODES` - simple: comma-separated URLs to your cluster seed nodes
 - `CLUSTER_ROOT_NODES_JSON` - advanced: JSON array of ClusterNode objects (ioredis)
 - `CLUSTER_OPTIONS_JSON` - advanced: JSON object of ClusterOptions (ioredis)
 
 #### MongoDB
+
 Mongo-specific options:
 
 - `CACHE_DATABASE_NAME` - Mongo database name (default is `proxy`)
 - `CACHE_COLLECTION_NAME` - Mongo collection name (default is `cache`)
-
 
 ### Horizontally scaling
 
 For horizontally scaled GrowthBook Proxy clusters, we provide a basic mechanism for keeping your proxy instances in sync, which uses Redis Pub/Sub. To use this feature, you must use Redis as your cache engine and set the following option:
 
 - `PUBLISH_PAYLOAD_TO_CHANNEL` - "true" or "1" to enable
-
 
 ### SSL termination & HTTP2
 
@@ -93,6 +99,8 @@ Although we recommend terminating SSL using your load balancer, you can also con
 - `USE_HTTP2` - "true" or "1" to enable
 - `HTTPS_CERT` - The SSL certificate
 - `HTTPS_KEY` - The SSL key
+
+If the GrowthBook app your proxy is connecting to is using a self-signed certificate, you can disable certificate verification by setting `NODE_TLS_REJECT_UNAUTHORIZED` to "0".
 
 ### Other common configuration options
 

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "node": ">=16"
   },
   "description": "GrowthBook proxy server for caching, realtime updates, telemetry, etc",
-  "version": "1.0.21",
+  "version": "1.0.22",
   "main": "dist/app.js",
   "license": "MIT",
   "repository": {

--- a/src/middleware/cache/readThroughCacheMiddleware.ts
+++ b/src/middleware/cache/readThroughCacheMiddleware.ts
@@ -78,6 +78,10 @@ export default async ({ proxyTarget }: { proxyTarget: string }) => {
         res.status(500).json({ message: "Proxy error" });
       },
       logLevel: "silent",
+      followRedirects: true,
+      ...(process.env.NODE_TLS_REJECT_UNAUTHORIZED === "0"
+        ? { secure: false }
+        : {}),
     });
   }
 

--- a/src/middleware/cache/refreshStaleCacheMiddleware.ts
+++ b/src/middleware/cache/refreshStaleCacheMiddleware.ts
@@ -24,7 +24,10 @@ export default ({ proxyTarget }: { proxyTarget: string }) =>
     activeFetchUrls.add(url);
     // eslint-disable-next-line no-async-promise-executor
     const entry = await got
-      .get(url, { headers: { "User-Agent": `GrowthBook Proxy` } })
+      .get(url, {
+        headers: { "User-Agent": `GrowthBook Proxy` },
+        rejectUnauthorized: process.env.NODE_TLS_REJECT_UNAUTHORIZED !== "0",
+      })
       .json()
       .catch((e) => logger.error(e, "Refresh stale cache error"))
       .finally(() => activeFetchUrls.delete(url));

--- a/src/middleware/proxyMiddleware.ts
+++ b/src/middleware/proxyMiddleware.ts
@@ -12,6 +12,10 @@ export default (req: Request, res: Response, next: NextFunction) => {
     scopedMiddlewares[registrar.growthbookApiHost] = createProxyMiddleware({
       target: registrar.growthbookApiHost,
       changeOrigin: true,
+      followRedirects: true,
+      ...(process.env.NODE_TLS_REJECT_UNAUTHORIZED === "0"
+        ? { secure: false }
+        : {}),
     });
   }
   return scopedMiddlewares[registrar.growthbookApiHost](req, res, next);

--- a/src/services/registrar/index.ts
+++ b/src/services/registrar/index.ts
@@ -98,7 +98,10 @@ export class Registrar {
       "User-Agent": `GrowthBook Proxy`,
     };
     const resp = (await got
-      .get(url, { headers })
+      .get(url, {
+        headers,
+        rejectUnauthorized: process.env.NODE_TLS_REJECT_UNAUTHORIZED !== "0",
+      })
       .json()
       .catch((e) => logger.error(e, "polling error"))) as
       | { connections: ConnectionDoc[] }


### PR DESCRIPTION
This PR adds support for the `NODE_TLS_REJECT_UNAUTHORIZED` environment variable to disable SSL certificate verification.  This is useful when your GrowthBook App server is using a self-signed certificate.

In addition, this PR enables the `followRedirects` option when proxying requests to the GrowthBook App