### PR TITLE
Relax (multi)orgs and sdk count constraints

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ docker run -d -p 3300:3300 \
 
 Then, simply point your GrowthBook SDKs to the GrowthBook Proxy instead of the GrowthBook API.
 
-You will need to create a "readonly" secret API key in GrowthBook by going to **Settings -> API Keys** (you can also use a Personal Access Token if preferred). This key will be used to authenticate your proxy server with the GrowthBook app.
+You will need to create a "readonly" secret API key in GrowthBook by going to **Settings -> API Keys** (you can also use a Personal Access Token if preferred). Or you can use a custom SECRET_API_KEY of your choosing<sup>✻</sup>. Whichever method you choose, this key will be used to authenticate your proxy server with the GrowthBook app.
 
 ### Self-hosted customers
 
@@ -73,6 +73,9 @@ You will also need to ensure that your self-hosted GrowthBook instance is config
 PROXY_ENABLED=1
 PROXY_HOST_PUBLIC=https://proxy.example.com
 ```
+
+✻ _If you are using a custom SECRET_API_KEY, you should also add an environment variable to your GrowthBook instance (ex: `SECRET_API_KEY=key_abc123`)._
+
 
 ### Cloud customers
 

--- a/README.md
+++ b/README.md
@@ -31,6 +31,10 @@ The GrowthBook Proxy repository is a mono-repo containing the following packages
 
 ### What's new
 
+**Version 1.1.1**
+- Multi organization support
+- Support paginated SDK Connection polling
+
 **Version 1.1.0**
 - Remote evaluation support added
 - Released `@growthbook/proxy-eval` package; reformatted codebase as a mono-repo
@@ -43,6 +47,7 @@ The GrowthBook Proxy repository is a mono-repo containing the following packages
 - Graceful shutdown
 - Stampede protection & debouncer for cache misses
 
+---
 
 ## Installation
 
@@ -58,23 +63,26 @@ docker run -d -p 3300:3300 \
 
 Then, simply point your GrowthBook SDKs to the GrowthBook Proxy instead of the GrowthBook API.
 
+You will need to create a "readonly" secret API key in GrowthBook by going to **Settings -> API Keys** (you can also use a Personal Access Token if preferred). This key will be used to authenticate your proxy server with the GrowthBook app.
+
 ### Self-hosted customers
 
-You will also need to ensure that your self-hosted GrowthBook instance is configured to use the proxy server. This includes setting environment variables:
+You will also need to ensure that your self-hosted GrowthBook instance is configured to use the proxy server. This includes setting environment variables in your GrowthBook instance (back-end):
 
 ```
 PROXY_ENABLED=1
 PROXY_HOST_PUBLIC=https://proxy.example.com
-
-## Optional; you may also use the GrowthBook UI to set this:
-SECRET_API_KEY=something_secret
 ```
-
-See GrowthBook's [Proxy documentation](https://docs.growthbook.io/self-host/proxy#standalone) for more information.
 
 ### Cloud customers
 
-For GrowthBook Cloud customers, use the GrowthBook app UI to create an API key in **Settings -> API Keys**. Additionally, you will need to set proxy's `GROWTHBOOK_API_HOST` environment variable to the cloud API server: `https://api.growthbook.io`.
+There are many reasons to self-host the GrowthBook Proxy (ex: low-latency consistent cache within your infrastructure, ability to customize SSE streaming). Additionally, Remote Evaluation is only available on a privately-hosted endpoint, such as this proxy server.
+
+You must enable your self-hosted GrowthBook Proxy by setting a custom proxy webhook URL for each SDK Connection via **SDK Configuration -> SDK Connections** in the GrowthBook app.
+
+---
+
+See GrowthBook's [Proxy documentation](https://docs.growthbook.io/self-host/proxy#standalone) for more information.
 
 ## Configuration
 
@@ -88,17 +96,17 @@ The GrowthBook Proxy supports a number of configuration options available via en
 
 By default, features are cached in memory in GrowthBook Proxy; you may provide your own cache service via Redis or Mongo. To fully utilize the GrowthBook Proxy, we highly recommend using Redis, which is a prerequisite for real-time updates when your proxy is horizontally scaled (as proxy instances are kept in-sync using Redis pub/sub).
 
-- `CACHE_ENGINE` - One of: `memory`, `redis`, or `mongo`
+- `CACHE_ENGINE` - One of: `memory`, `redis`, or `mongo` (default: `memory`)
 - `CACHE_CONNECTION_URL` - The URL of your Redis or Mongo Database
-- `CACHE_STALE_TTL` - Number of seconds until a cache entry is considered stale (default is `60` = 1 minute)
-- `CACHE_EXPIRES_TTL` - Number of seconds until a cache entry is expired (default is `600` = 10 minutes)
+- `CACHE_STALE_TTL` - Number of seconds until a cache entry is considered stale (default: `60` = 1 minute)
+- `CACHE_EXPIRES_TTL` - Number of seconds until a cache entry is expired (default: `600` = 10 minutes)
 
 #### Redis Cluster
 
 Redis-specific options for cluster mode:<br />
 _(Note that CACHE_CONNECTION_URL is ignored when using cluster mode)_
 
-- `USE_CLUSTER` - "true" or "1" to enable
+- `USE_CLUSTER` - "true" or "1" to enable (default: `false`)
 - `CLUSTER_ROOT_NODES` - simple: comma-separated URLs to your cluster seed nodes
 - `CLUSTER_ROOT_NODES_JSON` - advanced: JSON array of ClusterNode objects (ioredis)
 - `CLUSTER_OPTIONS_JSON` - advanced: JSON object of ClusterOptions (ioredis)
@@ -107,20 +115,20 @@ _(Note that CACHE_CONNECTION_URL is ignored when using cluster mode)_
 
 Mongo-specific options:
 
-- `CACHE_DATABASE_NAME` - Mongo database name (default is `proxy`)
-- `CACHE_COLLECTION_NAME` - Mongo collection name (default is `cache`)
+- `CACHE_DATABASE_NAME` - Mongo database name (default: `proxy`)
+- `CACHE_COLLECTION_NAME` - Mongo collection name (default: `cache`)
 
 ### Horizontally scaling
 
 For horizontally scaled GrowthBook Proxy clusters, we provide a basic mechanism for keeping your proxy instances in sync, which uses Redis Pub/Sub. To use this feature, you must use Redis as your cache engine and set the following option:
 
-- `PUBLISH_PAYLOAD_TO_CHANNEL` - "true" or "1" to enable
+- `PUBLISH_PAYLOAD_TO_CHANNEL` (Redis) - "true" or "1" to enable (default: `false`)
 
 ### SSL termination & HTTP2
 
 Although we recommend terminating SSL using your load balancer, you can also configure the GrowthBook Proxy to handle SSL termination directly. It supports HTTP/2 by default, which is required for high performance streaming.
 
-- `USE_HTTP2` - "true" or "1" to enable
+- `USE_HTTP2` - "true" or "1" to enable (default: `false`)
 - `HTTPS_CERT` - The SSL certificate
 - `HTTPS_KEY` - The SSL key
 
@@ -128,13 +136,16 @@ If the GrowthBook app your proxy is connecting to is using a self-signed certifi
 
 ### Other common configuration options
 
-- `MAX_PAYLOAD_SIZE` - The maximum size of a request body (default is `"2mb"`)
-- `VERBOSE_DEBUGGING` - "true" or "1" to enable verbose debugging
-
 **Streaming**
-- `ENABLE_EVENT_STREAM` - "true" or "1" to enable streaming (on by default)
-- `EVENT_STREAM_MAX_DURATION_MS` - The maximum duration of a SSE connection before the client is forced to reconnect (default is `60000` = 1 minute)
-- `EVENT_STREAM_PING_INTERVAL_MS` - The interval between SSE "ping" messages sent to the client (default is `30000` = 30 seconds)
+- `ENABLE_EVENT_STREAM` - "true" or "1" to enable streaming (default: `true`)
+- `EVENT_STREAM_MAX_DURATION_MS` - The maximum duration of a SSE connection before the client is forced to reconnect (default: `60000` = 1 minute)
+- `EVENT_STREAM_PING_INTERVAL_MS` - The interval between SSE "ping" messages sent to the client (default: `30000` = 30 seconds)
 
 **Remote Evaluation**
-- `ENABLE_REMOTE_EVAL` - "true" or "1" to enable remote evaluation (on by default)
+- `ENABLE_REMOTE_EVAL` - "true" or "1" to enable remote evaluation (default: `true`)
+
+**Misc**
+- `MAX_PAYLOAD_SIZE` - The maximum size of a request body (default: `"2mb"`)
+- `VERBOSE_DEBUGGING` - "true" or "1" to enable verbose debugging (default: `false`)
+- `CONNECTION_POLLING_FREQUENCY` - How frequently to refresh SDK connections (default: `60000` = 1 minute)
+- `MULTI_ORG` - "true" or "1" to enable multi-organization support (requires a compatible access token) (default: `false`)

--- a/packages/apps/proxy/package.json
+++ b/packages/apps/proxy/package.json
@@ -4,7 +4,7 @@
     "node": ">=18"
   },
   "description": "GrowthBook proxy server for caching, realtime updates, telemetry, etc",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "main": "dist/app.js",
   "license": "MIT",
   "repository": {

--- a/packages/apps/proxy/src/app.ts
+++ b/packages/apps/proxy/src/app.ts
@@ -43,7 +43,7 @@ const defaultContext: Context = {
   secretApiKey: "",
   createConnectionsFromEnv: true,
   pollForConnections: true,
-  connectionPollingFrequency: 10000,
+  connectionPollingFrequency: 60000,
   enableCache: true,
   cacheSettings: {
     cacheEngine: "memory",
@@ -69,6 +69,9 @@ export const growthBookProxy = async (
 
   const ctx: Context = { ...defaultContext, ...context };
   app.locals.ctx = ctx;
+  if (!ctx.growthbookApiHost) console.error("GROWTHBOOK_API_HOST is missing");
+  if (!ctx.secretApiKey) console.error("SECRET_API_KEY is missing");
+
 
   // initialize
   initializeLogger(ctx);

--- a/packages/apps/proxy/src/controllers/featuresController.ts
+++ b/packages/apps/proxy/src/controllers/featuresController.ts
@@ -106,6 +106,7 @@ const getEvaluatedFeatures = async (req: Request, res: Response) => {
       apiKey: res.locals.apiKey,
       ctx: req.app.locals?.ctx,
       remoteEvalEnabled: true,
+      organization: connection?.organization,
     });
     if (resp?.payload) {
       payload = resp?.payload;
@@ -123,6 +124,7 @@ const getEvaluatedFeatures = async (req: Request, res: Response) => {
       apiKey: res.locals.apiKey,
       ctx: req.app.locals?.ctx,
       remoteEvalEnabled: true,
+      organization: connection?.organization,
     }).catch((e) => {
       logger.error(e, "Unable to refresh stale cache");
     });

--- a/packages/apps/proxy/src/init.ts
+++ b/packages/apps/proxy/src/init.ts
@@ -11,27 +11,15 @@ export default async () => {
     environment: process.env.NODE_ENV as Context["environment"],
     enableAdmin: ["true", "1"].includes(process.env.ENABLE_ADMIN ?? "0"),
     adminKey: process.env.ADMIN_KEY,
+    multiOrg: ["true", "1"].includes(process.env.MULTI_ORG ?? "0"),
     verboseDebugging: ["true", "1"].includes(
       process.env.VERBOSE_DEBUGGING ?? "0",
     ),
     maxPayloadSize: process.env.MAX_PAYLOAD_SIZE ?? "2mb",
-    // SSE settings:
-    enableEventStream: ["true", "1"].includes(
-      process.env.ENABLE_EVENT_STREAM ?? "1",
-    ),
-    enableEventStreamHeaders: ["true", "1"].includes(
-      process.env.ENABLE_EVENT_STREAM_HEADERS ?? "1",
-    ),
-    eventStreamMaxDurationMs: parseInt(
-      process.env.EVENT_STREAM_MAX_DURATION_MS ?? "60000",
-    ),
-    eventStreamPingIntervalMs: parseInt(
-      process.env.EVENT_STREAM_PING_INTERVAL_MS ?? "30000",
-    ),
-    // Remote eval settings:
-    enableRemoteEval: ["true", "1"].includes(
-      process.env.ENABLE_REMOTE_EVAL ?? "1",
-    ),
+    // SDK Connections settings:
+    createConnectionsFromEnv: ["true", "1"].includes(process.env.CREATE_CONNECTIONS_FROM_ENV ?? "1"),
+    pollForConnections: ["true", "1"].includes(process.env.POLL_FOR_CONNECTIONS ?? "1"),
+    connectionPollingFrequency: parseInt(process.env.CONNECTION_POLLING_FREQUENCY ?? "60000"),
     // Cache settings:
     cacheSettings: {
       cacheEngine: (process.env.CACHE_ENGINE || "memory") as CacheEngine,
@@ -59,6 +47,23 @@ export default async () => {
         ? JSON.parse(process.env.CLUSTER_OPTIONS_JSON)
         : undefined,
     },
+    // SSE settings:
+    enableEventStream: ["true", "1"].includes(
+      process.env.ENABLE_EVENT_STREAM ?? "1",
+    ),
+    enableEventStreamHeaders: ["true", "1"].includes(
+      process.env.ENABLE_EVENT_STREAM_HEADERS ?? "1",
+    ),
+    eventStreamMaxDurationMs: parseInt(
+      process.env.EVENT_STREAM_MAX_DURATION_MS ?? "60000",
+    ),
+    eventStreamPingIntervalMs: parseInt(
+      process.env.EVENT_STREAM_PING_INTERVAL_MS ?? "30000",
+    ),
+    // Remote eval settings:
+    enableRemoteEval: ["true", "1"].includes(
+      process.env.ENABLE_REMOTE_EVAL ?? "1",
+    ),
   };
 
   // Express configuration consts:

--- a/packages/apps/proxy/src/services/features/index.ts
+++ b/packages/apps/proxy/src/services/features/index.ts
@@ -43,7 +43,7 @@ export async function fetchFeatures({
       }
       headers["Authorization"] = `Bearer ${ctx.secretApiKey}`;
     }
-    if (organization) {
+    if (organization && ctx.multiOrg) {
       headers["X-Organization"] = organization;
     }
 

--- a/packages/apps/proxy/src/services/features/index.ts
+++ b/packages/apps/proxy/src/services/features/index.ts
@@ -11,10 +11,12 @@ export async function fetchFeatures({
   apiKey,
   ctx,
   remoteEvalEnabled = false,
+  organization,
 }: {
   apiKey: string;
   ctx: Context;
   remoteEvalEnabled?: boolean;
+  organization?: string; // for multi-orgs
 }) {
   const path = remoteEvalEnabled
     ? `/api/v1/sdk-payload/${apiKey}`
@@ -40,6 +42,9 @@ export async function fetchFeatures({
         throw new Error("missing required context for fetching features");
       }
       headers["Authorization"] = `Bearer ${ctx.secretApiKey}`;
+    }
+    if (organization) {
+      headers["X-Organization"] = organization;
     }
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/packages/apps/proxy/src/types.ts
+++ b/packages/apps/proxy/src/types.ts
@@ -31,6 +31,7 @@ export interface Context {
   enableCors?: boolean;
   enableAdmin?: boolean;
   adminKey?: string;
+  multiOrg?: boolean;
   enableEventStream?: boolean;
   enableEventStreamHeaders?: boolean;
   eventStreamMaxDurationMs?: number;

--- a/packages/shared/eval/package.json
+++ b/packages/shared/eval/package.json
@@ -18,7 +18,7 @@
     "dev": "tsc --watch"
   },
   "dependencies": {
-    "@growthbook/growthbook": "^0.29.0"
+    "@growthbook/growthbook": "^0.30.0"
   },
   "devDependencies": {
     "rimraf": "^5.0.5",

--- a/packages/shared/eval/package.json
+++ b/packages/shared/eval/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@growthbook/proxy-eval",
   "description": "Remote evaluation service for proxies, edge workers, or backend APIs",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "main": "dist/index.js",
   "license": "MIT",
   "repository": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -46,12 +46,12 @@
   resolved "https://registry.yarnpkg.com/@eslint/js/-/js-8.50.0.tgz#9e93b850f0f3fa35f5fa59adfd03adae8488e484"
   integrity sha512-NCC3zz2+nvYd+Ckfh87rA47zfu2QsQpvc6k1yzTk+b9KzRj0wkGa8LSoGOXN6Zv4lRf/EIoZ80biDh9HOI+RNQ==
 
-"@growthbook/growthbook@^0.29.0":
-  version "0.29.0"
-  resolved "https://registry.yarnpkg.com/@growthbook/growthbook/-/growthbook-0.29.0.tgz#357f005d9fc28b4b018358d1dd2839066fca807a"
-  integrity sha512-hRYtBw1cg3fqjBRKRfazkRfCJyFpIxjdEUjmwkFaSBorzVDiX35gcp8x83vytQdx5E9xfQo3x/m9Z1yEMDrN7A==
+"@growthbook/growthbook@^0.30.0":
+  version "0.30.0"
+  resolved "https://registry.yarnpkg.com/@growthbook/growthbook/-/growthbook-0.30.0.tgz#52532c2d5dfa7c017815027678bb241421c308b1"
+  integrity sha512-ennMHKZIhAZokHHcnA9/tOTLFdBB4DQR0WHT8Lf1pD80jWVv8JBCAzsV1jzSjYUQhb8R8pLR2Kho0IfgjzIZGQ==
   dependencies:
-    dom-mutator "^0.5.0"
+    dom-mutator "^0.6.0"
 
 "@humanwhocodes/config-array@^0.11.11":
   version "0.11.11"
@@ -948,10 +948,10 @@ doctrine@^3.0.0:
   dependencies:
     esutils "^2.0.2"
 
-dom-mutator@^0.5.0:
-  version "0.5.0"
-  resolved "https://registry.yarnpkg.com/dom-mutator/-/dom-mutator-0.5.0.tgz#cd59f0afcc012e7f018717a9c79ce6a225c46782"
-  integrity sha512-bbeX8HWE8JGzraFgbVBX4ws2g3heZFuTtrleQBuN7huy+7n2n7etSuVnot3/1z3jdY2MiwuvoS4Ep1UT2rrGBw==
+dom-mutator@^0.6.0:
+  version "0.6.0"
+  resolved "https://registry.yarnpkg.com/dom-mutator/-/dom-mutator-0.6.0.tgz#079d7a4b3e8981a562cd777548b99baab51d65c5"
+  integrity sha512-iCt9o0aYfXMUkz/43ZOAUFQYotjGB+GNbYJiJdz4TgXkyToXbbRy5S6FbTp72lRBtfpUMwEc1KmpFEU4CZeoNg==
 
 dotenv@^16.0.3:
   version "16.3.1"


### PR DESCRIPTION
- Multi-org support for connection polling and remote-eval payload seeding
- A few more env var options as well, such as `MULTI_ORG` (bool)
- Support pagination for connection polling
- Latest SDK version
- a bit more debugging info