### PR TITLE
Update method to properly work with Redis Cluster

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ Redis-specific options for cluster mode:<br />
 _(Note that CACHE_CONNECTION_URL is ignored when using cluster mode)_
 
 - `USE_CLUSTER` - "true" or "1" to enable (default: `false`)
-- `CLUSTER_ROOT_NODES` - simple: comma-separated URLs to your cluster seed nodes
+- `CLUSTER_ROOT_NODES` - simple: comma-separated URLs to your cluster seed nodes. This need to be in the URL format (e.g redis://localhost:6379)
 - `CLUSTER_ROOT_NODES_JSON` - advanced: JSON array of ClusterNode objects (ioredis)
 - `CLUSTER_OPTIONS_JSON` - advanced: JSON object of ClusterOptions (ioredis)
 

--- a/README.md
+++ b/README.md
@@ -110,8 +110,7 @@ Redis-specific options for cluster mode:<br />
 _(Note that CACHE_CONNECTION_URL is ignored when using cluster mode)_
 
 - `USE_CLUSTER` - "true" or "1" to enable (default: `false`)
-- `CLUSTER_ROOT_NODES` - simple: comma-separated URLs to your cluster seed nodes. This need to be in the URL format (e.g redis://localhost:6379)
-- `CLUSTER_ROOT_NODES_JSON` - advanced: JSON array of ClusterNode objects (ioredis)
+- `CLUSTER_ROOT_NODES_JSON` - advanced: JSON array of ClusterNode objects (ioredis). Usually on `{ host: "url", port: 6379}` format.
 - `CLUSTER_OPTIONS_JSON` - advanced: JSON object of ClusterOptions (ioredis)
 
 #### MongoDB

--- a/packages/apps/proxy/src/init.ts
+++ b/packages/apps/proxy/src/init.ts
@@ -37,9 +37,6 @@ export default async () => {
       ),
       // Redis only - cluster:
       useCluster: ["true", "1"].includes(process.env.USE_CLUSTER ?? "0"),
-      clusterRootNodes: process.env.CLUSTER_ROOT_NODES
-        ? process.env.CLUSTER_ROOT_NODES.replace(" ", "").split(",")
-        : undefined,
       clusterRootNodesJSON: process.env.CLUSTER_ROOT_NODES_JSON
         ? JSON.parse(process.env.CLUSTER_ROOT_NODES_JSON)
         : undefined,

--- a/packages/apps/proxy/src/services/cache/RedisCache.ts
+++ b/packages/apps/proxy/src/services/cache/RedisCache.ts
@@ -275,7 +275,7 @@ export class RedisCache {
       .map((node) => {
         try {
           const url = new URL(node);
-          const host = url.protocol + "//" + url.hostname + url.pathname;
+          const host = url.hostname + url.pathname;
           const port = parseInt(url.port);
           return { host, port };
         } catch (e) {

--- a/packages/apps/proxy/src/services/cache/RedisCache.ts
+++ b/packages/apps/proxy/src/services/cache/RedisCache.ts
@@ -22,7 +22,6 @@ export class RedisCache {
   public readonly allowStale: boolean;
 
   private readonly useCluster: boolean;
-  private readonly clusterRootNodes?: ClusterNode[];
   private readonly clusterOptions?: ClusterOptions;
 
   private readonly appContext?: Context;
@@ -48,8 +47,7 @@ export class RedisCache {
     this.allowStale = allowStale;
     this.publishPayloadToChannel = publishPayloadToChannel;
     this.useCluster = useCluster;
-    this.clusterRootNodes =
-      clusterRootNodesJSON ?? this.transformRootNodes(clusterRootNodes);
+    this.clusterRootNodes = clusterRootNodesJSON;
     this.clusterOptions = clusterOptionsJSON;
 
     this.appContext = appContext;
@@ -267,23 +265,5 @@ export class RedisCache {
 
   public getsubscriberClient() {
     return this.subscriberClient;
-  }
-
-  private transformRootNodes(rootNodes?: string[]): ClusterNode[] | undefined {
-    if (!rootNodes) return undefined;
-    return rootNodes
-      .map((node) => {
-        try {
-          const url = new URL(node);
-          const host = url.hostname + url.pathname;
-          // If no port is specified we use the default one
-          const port = url.port ? parseInt(url.port) : 6379;
-          return { host, port };
-        } catch (e) {
-          logger.error(e, "Error parsing Redis cluster node");
-          return undefined;
-        }
-      })
-      .filter(Boolean) as ClusterNode[];
   }
 }

--- a/packages/apps/proxy/src/services/cache/RedisCache.ts
+++ b/packages/apps/proxy/src/services/cache/RedisCache.ts
@@ -276,7 +276,8 @@ export class RedisCache {
         try {
           const url = new URL(node);
           const host = url.hostname + url.pathname;
-          const port = parseInt(url.port);
+          // If no port is specified we use the default one
+          const port = url.port ? parseInt(url.port) : 6379;
           return { host, port };
         } catch (e) {
           logger.error(e, "Error parsing Redis cluster node");

--- a/packages/apps/proxy/src/services/cache/index.ts
+++ b/packages/apps/proxy/src/services/cache/index.ts
@@ -22,7 +22,6 @@ export interface CacheSettings {
   useAdditionalMemoryCache?: boolean;
   publishPayloadToChannel?: boolean; // for RedisCache pub/sub
   useCluster?: boolean; // for RedisCache
-  clusterRootNodes?: string[]; // for RedisCache
   clusterRootNodesJSON?: ClusterNode[]; // for RedisCache
   clusterOptionsJSON?: ClusterOptions; // for RedisCache
 }


### PR DESCRIPTION
It adds a default port if none is specified on `CLUSTER_ROOT_NODES` and removes the protocol to avoid connection errors when on cluster mode.

Further details on https://github.com/growthbook/growthbook-proxy/issues/37