### PR TITLE
Push image with git tag if set #44

### DIFF
--- a/.github/workflows/deploy-proxy.yml
+++ b/.github/workflows/deploy-proxy.yml
@@ -29,4 +29,8 @@ jobs:
           printf '%(%Y-%m-%dT%H:%M:%SZ)T' > buildinfo/DATE
           # Build and push the docker image
           docker build -t growthbook/proxy:latest -t growthbook/proxy:git-${GITHUB_SHA::7} .
+          tag=$(git tag --points-at HEAD)
+          if [ -n "$tag" ]; then
+            docker tag growthbook/proxy:latest growthbook/proxy:"$tag"
+          fi
           docker push -a growthbook/proxy


### PR DESCRIPTION
After https://github.com/growthbook/growthbook-proxy/issues/29 tags started being used but they are never pushed. This pushes the image with a tag if the built commit is tagged. This will not work if the tag is set after the push to main, in that case another workflow is required: trigger on tag -> tag docker tag growthbook/proxy:git-${GITHUB_SHA::7} growthbook/proxy:${tag} -> docker push -a growthbook/proxy