### PR TITLE
fix: add missing growthbook package to resolve docker runtime errors

### DIFF
--- a/packages/apps/proxy/package.json
+++ b/packages/apps/proxy/package.json
@@ -22,6 +22,8 @@
     "dev": "concurrently 'tsc --watch' 'nodemon -q dist/index.js | yarn pino-pretty'"
   },
   "dependencies": {
+    "@growthbook/growthbook": "^1.1.0",
+    "@growthbook/proxy-eval": "^1.0.3",
     "cors": "^2.8.5",
     "dotenv": "^16.0.3",
     "express": "^4.19.2",
@@ -30,8 +32,7 @@
     "mongodb": "^6.1.0",
     "pino-http": "^8.3.1",
     "spdy": "^4.0.2",
-    "uuid": "^9.0.0",
-    "@growthbook/proxy-eval": "^1.0.3"
+    "uuid": "^9.0.0"
   },
   "devDependencies": {
     "@types/cors": "^2.8.14",
@@ -44,7 +45,6 @@
     "nodemon": "^3.0.1",
     "pino-pretty": "^10.3.1",
     "rimraf": "^5.0.5",
-    "typescript": "5.2.2",
-    "@growthbook/growthbook": "^1.1.0"
+    "typescript": "5.2.2"
   }
 }


### PR DESCRIPTION
## Description

This pull request fixes https://github.com/growthbook/growthbook-proxy/issues/64 where the `growthbook/proxy:git-e724f6d` Docker image failed to start due to a missing dependency.

## Changes

* Added the `@growthbook/growthbook` package to the `dependencies` section of `packages/apps/proxy/package.json`.

## Testing

- Manually built and ran the Docker image using the updated `package.json`. The container started successfully without errors.