### PR TITLE
Fix for x509 certificate signed by unknown authority

### DIFF
--- a/.github/workflows/deploy-proxy.yml
+++ b/.github/workflows/deploy-proxy.yml
@@ -3,8 +3,8 @@ name: "Proxy: deploy"
 on:
   # Push to the main branch
   push:
-    branches:
-      - main
+    tags:
+      - "v*"
 
 jobs:
   # Build and publish the commit to docker

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,12 @@
 FROM node:18-slim
 WORKDIR /usr/local/src/app
 
+# Install ca-certificates
+RUN apt-get update && \
+  apt-get install -y ca-certificates && \
+  apt-get clean && \
+  rm -rf /var/lib/apt/lists/*
+
 # Copy over minimum files to install dependencies
 COPY package.json ./package.json
 COPY yarn.lock ./yarn.lock


### PR DESCRIPTION
The proxy service lacks CA certificates, resulting in an error message: `x509 certificate signed by unknown authority` when attempting to connect to an endpoint secured with SSL, such as a Vault server. 

Additionally, an issue was resolved https://github.com/growthbook/growthbook-proxy/issues/70 regarding the absence of semantic version Docker tags. The problem occurred because the workflow was triggered on the main branch before creating the Git tag. As a result, the workflow could not access the semantic version tag. This was fixed by changing the trigger to only include `v*` tags.