### PR TITLE
add redis sentinel config options

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,16 @@ _(Note that CACHE_CONNECTION_URL is ignored when using cluster mode)_
 - `CLUSTER_ROOT_NODES_JSON` - JSON array of ClusterNode objects (ioredis)
 - `CLUSTER_OPTIONS_JSON` - JSON object of ClusterOptions (ioredis)
 
+#### Redis Sentinel
+
+Redis-specific options for sentinel mode:<br />
+_(Note that CACHE_CONNECTION_URL is ignored when using sentinel mode)_
+Sentinel mode is only available if `USE_CLUSTER` is `false`
+
+- `USE_SENTINEL` - "true" or "1" to enable (default: `false`)
+- `SENTINEL_CONNECTION_OPTIONS_JSON` - JSON object of SentinelConnectionOptions (ioredis)
+  - Example: `{"sentinels": [{ "host": "localhost" , "port": 26379 }], "sentinelPassword": "password123", "password": "password123", "name": "mycache"}`
+
 #### MongoDB
 
 Mongo-specific options:

--- a/packages/apps/proxy/src/init.ts
+++ b/packages/apps/proxy/src/init.ts
@@ -54,6 +54,11 @@ export default async () => {
       clusterOptionsJSON: process.env.CLUSTER_OPTIONS_JSON
         ? JSON.parse(process.env.CLUSTER_OPTIONS_JSON)
         : undefined,
+      // Redis only - sentinel:
+      useSentinel: ["true", "1"].includes(process.env.USE_SENTINEL ?? "0"),
+      sentinelConnectionOptionsJSON: process.env.SENTINEL_CONNECTION_OPTIONS_JSON
+        ? JSON.parse(process.env.SENTINEL_CONNECTION_OPTIONS_JSON)
+        : undefined,
     },
     // SSE settings:
     enableEventStream: ["true", "1"].includes(

--- a/packages/apps/proxy/src/services/cache/index.ts
+++ b/packages/apps/proxy/src/services/cache/index.ts
@@ -1,4 +1,4 @@
-import { ClusterNode, ClusterOptions } from "ioredis";
+import { ClusterNode, ClusterOptions, SentinelConnectionOptions } from "ioredis";
 
 import { Context } from "../../types";
 import logger from "../logger";
@@ -24,6 +24,8 @@ export interface CacheSettings {
   useCluster?: boolean; // for RedisCache
   clusterRootNodesJSON?: ClusterNode[]; // for RedisCache
   clusterOptionsJSON?: ClusterOptions; // for RedisCache
+  useSentinel?: boolean; // for RedisCache
+  sentinelConnectionOptionsJSON?: SentinelConnectionOptions; // for RedisCache
 }
 
 export type FeaturesCache = MemoryCache | RedisCache | MongoCache | null;


### PR DESCRIPTION
Adds support for using [Redis Sentinel](https://redis.io/docs/latest/operate/oss_and_stack/management/sentinel/) as a cache backend