### PR TITLE
fix: broken utm attributes

### DIFF
--- a/packages/lib/edge-utils/src/attributes.ts
+++ b/packages/lib/edge-utils/src/attributes.ts
@@ -109,7 +109,7 @@ function getUtmAttributes(urlObj: URL) {
   let utms: Record<string, string> = {};
 
   // Add utm params from querystring
-  if (location.search) {
+  if (urlObj.search) {
     const params = new URLSearchParams(urlObj.search);
     ["source", "medium", "campaign", "term", "content"].forEach((k) => {
       // Querystring is in snake_case


### PR DESCRIPTION
It seems that utm attributes are never added because the `location` property does not exist in the edge environment. The error was not caught earlier because we have a `try/catch` block in the `getAutoAttributes` function where `catch` is ignored.