### PR TITLE
Add script and workflow to sync to growthbook-proxy-cloud

### DIFF
--- a/.github/scripts/sync-proxy-to-cloud.mjs
+++ b/.github/scripts/sync-proxy-to-cloud.mjs
@@ -1,0 +1,66 @@
+#!/usr/bin/env node
+/**
+ * Syncs growthbook-proxy to growthbook-proxy-cloud:
+ * 1. Patches app.js to inject version (removes package.json require)
+ * 2. Runs pnpm add for each proxy dependency to sync package.json
+ *
+ * Run from proxy-cloud directory. Expects growthbook-proxy repo at ../ (parent).
+ */
+
+import fs from "fs";
+import path from "path";
+import { fileURLToPath } from "url";
+import { execSync } from "child_process";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const proxyCloudDir = process.cwd();
+// In CI: proxy-cloud is inside growthbook-proxy, so .. = proxy repo
+// Locally: proxy-cloud and growthbook-proxy are siblings under growthbook/
+const parentDir = path.resolve(proxyCloudDir, "..");
+const proxyRepoDir = fs.existsSync(path.join(parentDir, "packages/apps/proxy/package.json"))
+  ? parentDir
+  : path.join(parentDir, "growthbook-proxy");
+
+const proxyPkg = JSON.parse(
+  fs.readFileSync(path.join(proxyRepoDir, "packages/apps/proxy/package.json"), "utf8")
+);
+const evalPkg = JSON.parse(
+  fs.readFileSync(path.join(proxyRepoDir, "packages/lib/eval/package.json"), "utf8")
+);
+
+const version = proxyPkg.version ?? "unknown";
+console.log("Proxy version:", version);
+
+// 1. Patch app.js
+const appPath = path.join(proxyCloudDir, "src/proxy-app/app.js");
+let content = fs.readFileSync(appPath, "utf8");
+
+// Replace: const packageJson = require("../package.json");\n    exports.version = ...
+// or: const packageJson = require("./package.json");\n    exports.version = ...
+content = content.replace(
+  /const packageJson = require\(["'].*?package\.json["']\);\s*\n\s*exports\.version = \(.*?\) \+ "";/s,
+  `exports.version = "${version}" + "";`
+);
+
+fs.writeFileSync(appPath, content);
+console.log("Patched app.js");
+
+// 2. Sync dependencies
+const depsToAdd = [];
+for (const [name, range] of Object.entries(proxyPkg.dependencies || {})) {
+  if (range === "workspace:*") {
+    if (name === "@growthbook/proxy-eval") {
+      depsToAdd.push(`${name}@^${evalPkg.version}`);
+    }
+  } else if (name !== "pm2") {
+    depsToAdd.push(`${name}@${range}`);
+  }
+}
+
+if (depsToAdd.length > 0) {
+  console.log("Adding dependencies:", depsToAdd.join(", "));
+  execSync(`pnpm add ${depsToAdd.join(" ")}`, {
+    cwd: proxyCloudDir,
+    stdio: "inherit",
+  });
+}

--- a/.github/workflows/sync-to-proxy-cloud.yml
+++ b/.github/workflows/sync-to-proxy-cloud.yml
@@ -44,8 +44,6 @@ jobs:
           rm -rf proxy-cloud/src/proxy-app
           mkdir -p proxy-cloud/src/proxy-app
           cp -r packages/apps/proxy/dist/* proxy-cloud/src/proxy-app/
-          # Remove package.json if present (version is patched into app.js instead)
-          rm -f proxy-cloud/src/proxy-app/package.json
 
       - name: Patch app.js with version and sync dependencies
         run: |

--- a/.github/workflows/sync-to-proxy-cloud.yml
+++ b/.github/workflows/sync-to-proxy-cloud.yml
@@ -1,0 +1,66 @@
+# Syncs proxy dist to growthbook-proxy-cloud on push to main.
+# Requires: GH_PAT secret with repo scope (to push to growthbook-proxy-cloud).
+name: Sync to growthbook-proxy-cloud
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "packages/apps/proxy/**"
+      - "packages/lib/eval/**"
+      - ".github/workflows/sync-to-proxy-cloud.yml"
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    if: github.repository == 'growthbook/growthbook-proxy'
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout growthbook-proxy
+        uses: actions/checkout@v4
+
+      - name: Enable corepack
+        run: corepack enable
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: "pnpm"
+
+      - name: Install and build proxy
+        run: pnpm build:proxy
+
+      - name: Checkout growthbook-proxy-cloud
+        uses: actions/checkout@v4
+        with:
+          repository: growthbook/growthbook-proxy-cloud
+          token: ${{ secrets.GH_PAT }}
+          path: proxy-cloud
+
+      - name: Copy proxy dist to proxy-cloud
+        run: |
+          rm -rf proxy-cloud/src/proxy-app
+          mkdir -p proxy-cloud/src/proxy-app
+          cp -r packages/apps/proxy/dist/* proxy-cloud/src/proxy-app/
+          # Remove package.json if present (version is patched into app.js instead)
+          rm -f proxy-cloud/src/proxy-app/package.json
+
+      - name: Patch app.js with version and sync dependencies
+        run: |
+          cd proxy-cloud
+          node ../.github/scripts/sync-proxy-to-cloud.mjs
+
+      - name: Commit and push
+        run: |
+          cd proxy-cloud
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add src/proxy-app package.json pnpm-lock.yaml
+          if git diff --staged --quiet; then
+            echo "No changes to commit"
+          else
+            git commit -m "chore: sync proxy from growthbook-proxy@${{ github.sha }}"
+            git push
+          fi


### PR DESCRIPTION
Syncs repo on merge to growthbook-proxy-cloud, which will then deploy it.

This has a script and github action that:
- Builds the proxy (pnpm build:proxy)
- Copies dist/* → src/proxy-app/ in this repo
- Patches app.js to inject the version from package.json
- Runs pnpm add for each proxy dependency to keep this repo's package.json in sync
- Commits and pushes the changes

### Dependencies
- Needs a `GH_PAT` secret in with `repo` scope
- To deploy safely the first time we should remove the automatic deploy workflow in `growthbook-proxy-cloud`.  When this get's merged we should see the new commit in `growthbook-proxy-cloud`.  We would then build and fully test it's docker image.  Then we would re-enable the deploy workflow and manually run it.

### Test Plan
Run the same commands as the gitub action (translated to local directories) (and except the git push):
```
pnpm build:proxy
rm -rf ../growthbook-proxy-cloud/src/proxy-app
mkdir -p ../growthbook-proxy-cloud/src/proxy-app
cp -r packages/apps/proxy/dist/* ../growthbook-proxy-cloud/src/proxy-app/
cd ../growthbook-proxy-cloud
node ../growthbook-proxy/.github/scripts/sync-proxy-to-cloud.mjs
```
Saw that there were no changes to commit in the growthbook-proxy-cloud repo.
Added a `console.log("TEST THAT IT GETS COPIED TO CLOUD");` to `packages/apps/proxy/src/app.ts`.  Then again ran the above commands.
Saw that the `console.log("TEST THAT IT GETS COPIED TO CLOUD");`  line was now in `../growthbook-cloud-proxy/src/proxy-app/app.js`.


