### PR TITLE
Fix script to deploy proxy to cloud

### DIFF
--- a/.github/scripts/sync-proxy-to-cloud.mjs
+++ b/.github/scripts/sync-proxy-to-cloud.mjs
@@ -17,29 +17,42 @@ const proxyCloudDir = process.cwd();
 // In CI: proxy-cloud is inside growthbook-proxy, so .. = proxy repo
 // Locally: proxy-cloud and growthbook-proxy are siblings under growthbook/
 const parentDir = path.resolve(proxyCloudDir, "..");
-const proxyRepoDir = fs.existsSync(path.join(parentDir, "packages/apps/proxy/package.json"))
+const proxyRepoDir = fs.existsSync(
+  path.join(parentDir, "packages/apps/proxy/package.json"),
+)
   ? parentDir
   : path.join(parentDir, "growthbook-proxy");
 
 const proxyPkg = JSON.parse(
-  fs.readFileSync(path.join(proxyRepoDir, "packages/apps/proxy/package.json"), "utf8")
+  fs.readFileSync(
+    path.join(proxyRepoDir, "packages/apps/proxy/package.json"),
+    "utf8",
+  ),
 );
 const evalPkg = JSON.parse(
-  fs.readFileSync(path.join(proxyRepoDir, "packages/lib/eval/package.json"), "utf8")
+  fs.readFileSync(
+    path.join(proxyRepoDir, "packages/lib/eval/package.json"),
+    "utf8",
+  ),
 );
 
 const version = proxyPkg.version ?? "unknown";
 console.log("Proxy version:", version);
 
-// 1. Patch app.js
+// 1. Patch app.js — remove the package.json require and hardcode the version
 const appPath = path.join(proxyCloudDir, "src/proxy-app/app.js");
 let content = fs.readFileSync(appPath, "utf8");
 
-// Replace: const packageJson = require("../package.json");\n    exports.version = ...
-// or: const packageJson = require("./package.json");\n    exports.version = ...
+// Remove: const package_json_1 = __importDefault(require("../package.json"));
 content = content.replace(
-  /const packageJson = require\(["'].*?package\.json["']\);\s*\n\s*exports\.version = \(.*?\) \+ "";/s,
-  `exports.version = "${version}" + "";`
+  /const package_json_1 = __importDefault\(require\(["'].*?package\.json["']\)\);\n/,
+  "",
+);
+
+// Replace the version export with a hardcoded string
+content = content.replace(
+  /exports\.version = \(.*?\) \+ "";/s,
+  `exports.version = "${version}" + "";`,
 );
 
 fs.writeFileSync(appPath, content);

--- a/.github/scripts/sync-proxy-to-cloud.mjs
+++ b/.github/scripts/sync-proxy-to-cloud.mjs
@@ -44,14 +44,26 @@ const appPath = path.join(proxyCloudDir, "src/proxy-app/app.js");
 let content = fs.readFileSync(appPath, "utf8");
 
 // Remove: const package_json_1 = __importDefault(require("../package.json"));
-content = content.replace(
-  /const package_json_1 = __importDefault\(require\(["'].*?package\.json["']\)\);\n/,
-  "",
-);
+const requirePattern =
+  /const package_json_1 = __importDefault\(require\(["'].*?package\.json["']\)\);\n/;
+if (!requirePattern.test(content)) {
+  console.error(
+    "Failed to find package.json require in app.js — compiled output may have changed",
+  );
+  process.exit(1);
+}
+content = content.replace(requirePattern, "");
 
 // Replace the version export with a hardcoded string
+const versionPattern = /exports\.version = \(.*?\) \+ "";/s;
+if (!versionPattern.test(content)) {
+  console.error(
+    "Failed to find exports.version assignment in app.js — compiled output may have changed",
+  );
+  process.exit(1);
+}
 content = content.replace(
-  /exports\.version = \(.*?\) \+ "";/s,
+  versionPattern,
   `exports.version = "${version}" + "";`,
 );
 

--- a/.github/workflows/sync-to-proxy-cloud.yml
+++ b/.github/workflows/sync-to-proxy-cloud.yml
@@ -48,7 +48,7 @@ jobs:
         run: |
           rm -rf proxy-cloud/src/proxy-app
           mkdir -p proxy-cloud/src/proxy-app
-          cp -r packages/apps/proxy/dist/* proxy-cloud/src/proxy-app/
+          cp -r packages/apps/proxy/dist/src/* proxy-cloud/src/proxy-app/
 
       - name: Patch app.js with version and sync dependencies
         run: |


### PR DESCRIPTION
The compiled directory was wrong... the actual data lives in dist/src.  
Also the compiled output changed. I've updated the script and put in checks to make sure that the script fails if it did not actually change the code.

Test plan:
Ran the script translated to what the directories actually are locally for me.
```
pnpm build:proxy
rm -rf ../growthbook-proxy-cloud/src/proxy-app                             
mkdir -p ../growthbook-proxy-cloud/src/proxy-app                             
cp -r packages/apps/proxy/dist/src/* ../growthbook-proxy-cloud/src/proxy-app/
cd ../growthbook-proxy-cloud
node ../growthbook-proxy/.github/scripts/sync-proxy-to-cloud.mjs
```