### PR TITLE
Address security vulnerabilities (2026-04-21)

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,10 @@
   "pnpm": {
     "overrides": {
       "picomatch@2": ">=2.3.2",
-      "path-to-regexp@8": ">=8.4.0"
+      "picomatch@4": "^4.0.4",
+      "path-to-regexp@8": ">=8.4.0",
+      "protobufjs@7": "^7.5.5",
+      "follow-redirects@1": "^1.16.0"
     }
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,7 +7,10 @@ settings:
 
 overrides:
   picomatch@2: ">=2.3.2"
+  picomatch@4: ^4.0.4
   path-to-regexp@8: ">=8.4.0"
+  protobufjs@7: ^7.5.5
+  follow-redirects@1: ^1.16.0
 
 importers:
   .:
@@ -2528,6 +2531,7 @@ packages:
         integrity: sha512-VoMINM2rqJwJgfdHq6RiUudKt2BV+FY5ZFezP/ypmwayk68+NzzAQy4XXLlqsGD4MCzq3DrmNFD/uUmBJuGoXw==,
       }
     engines: { node: ">=10.0.0" }
+    deprecated: Security vulnerability fixed in 5.2.1, please upgrade
 
   bignumber.js@9.3.1:
     resolution:
@@ -3470,7 +3474,7 @@ packages:
       }
     engines: { node: ">=12.0.0" }
     peerDependencies:
-      picomatch: ^3 || ^4
+      picomatch: ^4.0.4
     peerDependenciesMeta:
       picomatch:
         optional: true
@@ -3516,10 +3520,10 @@ packages:
         integrity: sha512-3+mMldrTAPdta5kjX2G2J7iX4zxtnwpdA8Tr2ZSjkyPSanvbZAcy6flmtnXbEybHrDcU9641lxrMfFuUxVz9vA==,
       }
 
-  follow-redirects@1.15.11:
+  follow-redirects@1.16.0:
     resolution:
       {
-        integrity: sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==,
+        integrity: sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==,
       }
     engines: { node: ">=4.0" }
     peerDependencies:
@@ -4865,10 +4869,10 @@ packages:
       }
     engines: { node: ">=4" }
 
-  picomatch@4.0.3:
+  picomatch@4.0.4:
     resolution:
       {
-        integrity: sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==,
+        integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==,
       }
     engines: { node: ">=12" }
 
@@ -5055,10 +5059,10 @@ packages:
         integrity: sha512-aC9j+BZsRSSzEsXBNBwDnAxujdx19HycZoKgRgzWnS8eOHg1asuf9heuLprfbe739zY3IdUQx+Egv6Jn135WHA==,
       }
 
-  protobufjs@7.5.4:
+  protobufjs@7.5.5:
     resolution:
       {
-        integrity: sha512-CvexbZtbov6jW2eXAvLukXjXUW1TzFaivC46BpWc/3BpcCysb5Vffu+B3XHMm8lVEuy2Mm4XGex8hBSg1yapPg==,
+        integrity: sha512-3wY1AxV+VBNW8Yypfd1yQY9pXnqTAN+KwQxL8iYm3/BjKYMNg4i0owhEe26PWDOMaIrzeeF98Lqd5NGz4omiIg==,
       }
     engines: { node: ">=12.0.0" }
 
@@ -6388,7 +6392,7 @@ snapshots:
     dependencies:
       lodash.camelcase: 4.3.0
       long: 5.3.2
-      protobufjs: 7.5.4
+      protobufjs: 7.5.5
       yargs: 17.7.2
 
   "@humanfs/core@0.19.1": {}
@@ -7014,7 +7018,7 @@ snapshots:
       "@opentelemetry/sdk-logs": 0.52.1(@opentelemetry/api@1.9.0)
       "@opentelemetry/sdk-metrics": 1.25.1(@opentelemetry/api@1.9.0)
       "@opentelemetry/sdk-trace-base": 1.25.1(@opentelemetry/api@1.9.0)
-      protobufjs: 7.5.4
+      protobufjs: 7.5.5
 
   "@opentelemetry/propagation-utils@0.30.16(@opentelemetry/api@1.9.0)":
     dependencies:
@@ -7576,7 +7580,7 @@ snapshots:
   anymatch@3.1.3:
     dependencies:
       normalize-path: 3.0.0
-      picomatch: 4.0.3
+      picomatch: 4.0.4
 
   argparse@2.0.1: {}
 
@@ -8293,7 +8297,7 @@ snapshots:
 
   extrareqp2@1.0.0(debug@4.3.7):
     dependencies:
-      follow-redirects: 1.15.11(debug@4.3.7)
+      follow-redirects: 1.16.0(debug@4.3.7)
     transitivePeerDependencies:
       - debug
 
@@ -8311,9 +8315,9 @@ snapshots:
 
   fclone@1.0.11: {}
 
-  fdir@6.5.0(picomatch@4.0.3):
+  fdir@6.5.0(picomatch@4.0.4):
     optionalDependencies:
-      picomatch: 4.0.3
+      picomatch: 4.0.4
 
   file-entry-cache@8.0.0:
     dependencies:
@@ -8346,11 +8350,11 @@ snapshots:
 
   flatted@3.3.4: {}
 
-  follow-redirects@1.15.11(debug@4.3.7):
+  follow-redirects@1.16.0(debug@4.3.7):
     optionalDependencies:
       debug: 4.3.7
 
-  follow-redirects@1.15.11(debug@4.4.3):
+  follow-redirects@1.16.0(debug@4.4.3):
     optionalDependencies:
       debug: 4.4.3(supports-color@5.5.0)
 
@@ -8541,7 +8545,7 @@ snapshots:
   http-proxy@1.18.1(debug@4.4.3):
     dependencies:
       eventemitter3: 4.0.7
-      follow-redirects: 1.15.11(debug@4.4.3)
+      follow-redirects: 1.16.0(debug@4.4.3)
       requires-port: 1.0.0
     transitivePeerDependencies:
       - debug
@@ -8865,7 +8869,7 @@ snapshots:
   micromatch@4.0.8:
     dependencies:
       braces: 3.0.3
-      picomatch: 4.0.3
+      picomatch: 4.0.4
 
   mime-db@1.54.0: {}
 
@@ -9111,7 +9115,7 @@ snapshots:
       postgres-date: 1.0.7
       postgres-interval: 1.2.0
 
-  picomatch@4.0.3: {}
+  picomatch@4.0.4: {}
 
   pidtree@0.6.0: {}
 
@@ -9285,7 +9289,7 @@ snapshots:
     dependencies:
       read: 1.0.7
 
-  protobufjs@7.5.4:
+  protobufjs@7.5.5:
     dependencies:
       "@protobufjs/aspromise": 1.1.2
       "@protobufjs/base64": 1.1.2
@@ -9374,7 +9378,7 @@ snapshots:
 
   readdirp@3.6.0:
     dependencies:
-      picomatch: 4.0.3
+      picomatch: 4.0.4
 
   real-require@0.2.0: {}
 
@@ -9795,8 +9799,8 @@ snapshots:
 
   tinyglobby@0.2.15:
     dependencies:
-      fdir: 6.5.0(picomatch@4.0.3)
-      picomatch: 4.0.3
+      fdir: 6.5.0(picomatch@4.0.4)
+      picomatch: 4.0.4
 
   to-regex-range@5.0.1:
     dependencies:


### PR DESCRIPTION
## Summary

Bumps `picomatch`, `protobufjs`, and `follow-redirects` via pnpm overrides — all within major. Ran `pnpm dedupe` to collapse a stale picomatch@4.0.3 entry (kept alive by anymatch@3.1.3).

## Fixed

| Package | From → To | CVE | Notes |
|---|---|---|---|
| `picomatch@4` (override, new) | `4.0.3` → `^4.0.4` | CVE-2026-33671, CVE-2026-33672 | |
| `protobufjs@7` (override, new) | `7.5.4` → `^7.5.5` | CVE-2026-41242 | 7.5.5 is the 7.x backport per GHSA-xq3m-2v4x-88gg |
| `follow-redirects@1` (override, new) | `1.15.11` → `^1.16.0` | GHSA-r4q5-vmmm-2653 | |

## Skipped

### Node-bundled OpenSSL (5 HIGHs, GENERIC manager)
- `openssl/openssl 3.5.5 → 3.6.2` (bundled inside the `node:22-slim` binary)
- CVE-2026-2673, CVE-2026-31790, CVE-2026-28388, CVE-2026-28389, CVE-2026-28390
- No Node release ships openssl ≥ 3.6 yet (latest 22.22.2 bundles 3.5.5). Will clear when Node upstream bumps.

## Test plan

- [ ] CI passes (type-check, lint)
- [ ] Docker image builds
- [ ] Re-scan confirms picomatch/protobufjs/follow-redirects findings clear

🤖 Generated with [Claude Code](https://claude.com/claude-code)