### PR TITLE
Fix sync script again

### DIFF
--- a/.github/workflows/sync-to-proxy-cloud.yml
+++ b/.github/workflows/sync-to-proxy-cloud.yml
@@ -48,7 +48,7 @@ jobs:
         run: |
           rm -rf proxy-cloud/src/proxy-app
           mkdir -p proxy-cloud/src/proxy-app
-          cp -r packages/apps/proxy/dist/src/* proxy-cloud/src/proxy-app/
+          cp -r packages/apps/proxy/dist/* proxy-cloud/src/proxy-app/
 
       - name: Patch app.js with version and sync dependencies
         run: |

--- a/packages/apps/proxy/package.json
+++ b/packages/apps/proxy/package.json
@@ -15,7 +15,7 @@
   },
   "author": "Bryce Fitzsimons",
   "scripts": {
-    "build:clean": "rimraf -rf dist",
+    "build:clean": "rimraf -rf dist tsconfig.tsbuildinfo",
     "build:typescript": "tsc",
     "build": "pnpm build:clean && pnpm build:typescript",
     "type-check": "tsc --pretty --noEmit",


### PR DESCRIPTION
We [changed](https://github.com/growthbook/growthbook-proxy/commit/8f6105b6edbd729a405aeb7ae9653a18e9e8a26a#diff-c17e43d7ef845cf5d5fce47b4bae12d060c95ed8fd4439eb5929365a4e966ea1R11) in tsconfig where the proxy app is built to.  That broke the sync script.  This fixes it.  It also cleans the tsconfig cache when rebuilding which can get messed up.

Test plan:
Ran the script translated to what the directories actually are locally for me.
```
pnpm build:proxy
rm -rf ../growthbook-proxy-cloud/src/proxy-app                             
mkdir -p ../growthbook-proxy-cloud/src/proxy-app                             
cp -r packages/apps/proxy/dist/* ../growthbook-proxy-cloud/src/proxy-app/
cd ../growthbook-proxy-cloud
node ../growthbook-proxy/.github/scripts/sync-proxy-to-cloud.mjs
```