### PR TITLE
Address security vulnerabilities (2026-05-27)

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,11 @@
   "pnpm": {
     "overrides": {
       "picomatch@2": ">=2.3.2",
-      "path-to-regexp@8": ">=8.4.0"
+      "picomatch@4": "^4.0.4",
+      "path-to-regexp@8": ">=8.4.0",
+      "follow-redirects@1": "^1.16.0",
+      "qs@6": "^6.15.2",
+      "@protobufjs/utf8@1": "^1.1.1"
     }
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,7 +7,11 @@ settings:
 
 overrides:
   picomatch@2: ">=2.3.2"
+  picomatch@4: ^4.0.4
   path-to-regexp@8: ">=8.4.0"
+  follow-redirects@1: ^1.16.0
+  qs@6: ^6.15.2
+  "@protobufjs/utf8@1": ^1.1.1
 
 importers:
   .:
@@ -2234,10 +2238,10 @@ packages:
         integrity: sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==,
       }
 
-  "@protobufjs/utf8@1.1.0":
+  "@protobufjs/utf8@1.1.1":
     resolution:
       {
-        integrity: sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==,
+        integrity: sha512-oOAWABowe8EAbMyWKM0tYDKi8Yaox52D+HWZhAIJqQXbqe0xI/GV7FhLWqlEKreMkfDjshR5FKgi3mnle0h6Eg==,
       }
 
   "@rtsao/scc@1.1.0":
@@ -4220,7 +4224,7 @@ packages:
       }
     engines: { node: ">=12.0.0" }
     peerDependencies:
-      picomatch: ^3 || ^4
+      picomatch: ^4.0.4
     peerDependenciesMeta:
       picomatch:
         optional: true
@@ -4273,10 +4277,10 @@ packages:
         integrity: sha512-3+mMldrTAPdta5kjX2G2J7iX4zxtnwpdA8Tr2ZSjkyPSanvbZAcy6flmtnXbEybHrDcU9641lxrMfFuUxVz9vA==,
       }
 
-  follow-redirects@1.15.11:
+  follow-redirects@1.16.0:
     resolution:
       {
-        integrity: sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==,
+        integrity: sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==,
       }
     engines: { node: ">=4.0" }
     peerDependencies:
@@ -6140,6 +6144,13 @@ packages:
       }
     engines: { node: ">=12" }
 
+  picomatch@4.0.4:
+    resolution:
+      {
+        integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==,
+      }
+    engines: { node: ">=12" }
+
   pidtree@0.6.0:
     resolution:
       {
@@ -6403,10 +6414,10 @@ packages:
         integrity: sha512-bVWawvoZoBYpp6yIoQtQXHZjmz35RSVHnUOTefl8Vcjr8snTPY1wnpSPMWekcFwbxI6gtmT7rSYPFvz71ldiOA==,
       }
 
-  qs@6.15.0:
+  qs@6.15.2:
     resolution:
       {
-        integrity: sha512-mAZTtNCeetKMH+pSjrb76NAM8V9a05I9aBZOHztWy/UqcJdQYNsf59vrRKWnojAT9Y+GbIvoTBC++CPHqpDBhQ==,
+        integrity: sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==,
       }
     engines: { node: ">=0.6" }
 
@@ -9114,7 +9125,7 @@ snapshots:
 
   "@protobufjs/pool@1.1.0": {}
 
-  "@protobufjs/utf8@1.1.0": {}
+  "@protobufjs/utf8@1.1.1": {}
 
   "@rtsao/scc@1.1.0": {}
 
@@ -9672,7 +9683,7 @@ snapshots:
       http-errors: 2.0.1
       iconv-lite: 0.7.2
       on-finished: 2.4.1
-      qs: 6.15.0
+      qs: 6.15.2
       raw-body: 3.0.2
       type-is: 2.0.1
     transitivePeerDependencies:
@@ -10365,7 +10376,7 @@ snapshots:
       once: 1.4.0
       parseurl: 1.3.3
       proxy-addr: 2.0.7
-      qs: 6.15.0
+      qs: 6.15.2
       range-parser: 1.2.1
       router: 2.2.0
       send: 1.2.1
@@ -10380,7 +10391,7 @@ snapshots:
 
   extrareqp2@1.0.0(debug@4.3.7):
     dependencies:
-      follow-redirects: 1.15.11(debug@4.3.7)
+      follow-redirects: 1.16.0(debug@4.3.7)
     transitivePeerDependencies:
       - debug
 
@@ -10402,9 +10413,9 @@ snapshots:
 
   fclone@1.0.11: {}
 
-  fdir@6.5.0(picomatch@4.0.3):
+  fdir@6.5.0(picomatch@4.0.4):
     optionalDependencies:
-      picomatch: 4.0.3
+      picomatch: 4.0.4
 
   file-entry-cache@8.0.0:
     dependencies:
@@ -10442,11 +10453,11 @@ snapshots:
 
   flatted@3.3.4: {}
 
-  follow-redirects@1.15.11(debug@4.3.7):
+  follow-redirects@1.16.0(debug@4.3.7):
     optionalDependencies:
       debug: 4.3.7
 
-  follow-redirects@1.15.11(debug@4.4.3):
+  follow-redirects@1.16.0(debug@4.4.3):
     optionalDependencies:
       debug: 4.4.3(supports-color@5.5.0)
 
@@ -10667,7 +10678,7 @@ snapshots:
   http-proxy@1.18.1(debug@4.4.3):
     dependencies:
       eventemitter3: 4.0.7
-      follow-redirects: 1.15.11(debug@4.4.3)
+      follow-redirects: 1.16.0(debug@4.4.3)
       requires-port: 1.0.0
     transitivePeerDependencies:
       - debug
@@ -11680,6 +11691,8 @@ snapshots:
 
   picomatch@4.0.3: {}
 
+  picomatch@4.0.4: {}
+
   pidtree@0.6.0: {}
 
   pidusage@2.0.21:
@@ -11880,7 +11893,7 @@ snapshots:
       "@protobufjs/inquire": 1.1.0
       "@protobufjs/path": 1.1.2
       "@protobufjs/pool": 1.1.0
-      "@protobufjs/utf8": 1.1.0
+      "@protobufjs/utf8": 1.1.1
       "@types/node": 22.19.13
       long: 5.3.2
 
@@ -11915,7 +11928,7 @@ snapshots:
 
   pure-rand@6.1.0: {}
 
-  qs@6.15.0:
+  qs@6.15.2:
     dependencies:
       side-channel: 1.1.0
 
@@ -12421,8 +12434,8 @@ snapshots:
 
   tinyglobby@0.2.15:
     dependencies:
-      fdir: 6.5.0(picomatch@4.0.3)
-      picomatch: 4.0.3
+      fdir: 6.5.0(picomatch@4.0.4)
+      picomatch: 4.0.4
 
   tmpl@1.0.5: {}
 


### PR DESCRIPTION
## Summary

Adds `pnpm.overrides` entries for vulnerable transitive deps flagged by Vanta/AWS Inspector against the `proxy` ECR image. All bumps are in-major patches; `pnpm -r type-check` passes locally.

### Fixed

| Package | Change | Resolves |
|---|---|---|
| `picomatch@4` override (new) | `^4.0.4` | CVE-2026-33671, CVE-2026-33672 |
| `follow-redirects@1` override (new) | `^1.16.0` | GHSA-r4q5-vmmm-2653 |
| `qs@6` override (new) | `^6.15.2` | CVE-2026-8723 |
| `@protobufjs/utf8@1` override (new) | `^1.1.1` | CVE-2026-44288 |

### Skipped (cross-major / risky)

- **`protobufjs` 7.5.4 → 8.x** (multiple CVEs incl. CVE-2026-41242, CVE-2026-44289..44294, CVE-2026-45740). Pulled in by `@opentelemetry/auto-instrumentations-node@0.48`. No 7.x backport; requires a coordinated OTel constellation upgrade.
- **`@opentelemetry/auto-instrumentations-node` 0.48 → 0.75, `sdk-node` 0.52.1 → 0.217** (GHSA-q7rr-3cgh-j5r3). Same OTel-stack upgrade as protobufjs; deferring.
- **`uuid` 8.x / 9.x / 10.x → 13.x** (CVE-2026-41907). Transitive; the fix landed in 11.1.1+ so any patch crosses a major. Deferring.

### Skipped (base image / OS)

- Debian packages `gnutls28`, `glibc`, `dpkg`, `libcap2`, `libgcrypt20`, `systemd` and bundled OpenSSL — come from the `node:` base image. Will be picked up by the next image rebuild after upstream republishes.

## Test plan

- [x] `pnpm install` succeeds
- [x] `pnpm -r type-check` passes
- [ ] CI build green
- [ ] Post-deploy Vanta scan confirms the listed CVEs drop off