### PR TITLE
Address security vulnerabilities (2026-05-28)

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,8 @@
       "path-to-regexp@8": ">=8.4.0",
       "follow-redirects@1": "^1.16.0",
       "qs@6": "^6.15.2",
-      "@protobufjs/utf8@1": "^1.1.1"
+      "@protobufjs/utf8@1": "^1.1.1",
+      "protobufjs@7": "^7.6.1"
     }
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,6 +12,7 @@ overrides:
   follow-redirects@1: ^1.16.0
   qs@6: ^6.15.2
   "@protobufjs/utf8@1": ^1.1.1
+  protobufjs@7: ^7.6.1
 
 importers:
   .:
@@ -2207,22 +2208,22 @@ packages:
         integrity: sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==,
       }
 
-  "@protobufjs/codegen@2.0.4":
+  "@protobufjs/codegen@2.0.5":
     resolution:
       {
-        integrity: sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg==,
+        integrity: sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g==,
       }
 
-  "@protobufjs/eventemitter@1.1.0":
+  "@protobufjs/eventemitter@1.1.1":
     resolution:
       {
-        integrity: sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q==,
+        integrity: sha512-vW1GmwMZNnL+gMRaovlh9yZX74kc+TTU3FObkkurpMaRtBfLP3ldjS9KQWlwZgraRE0+dheEEoAxdzcJQ8eXZg==,
       }
 
-  "@protobufjs/fetch@1.1.0":
+  "@protobufjs/fetch@1.1.1":
     resolution:
       {
-        integrity: sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ==,
+        integrity: sha512-GpptLrs57adMSuHi3VNj0mAF8dwh36LMaYF6XyJ6JMWlVsc+t42tm1HSEDmOs3A8fC9yyeisgLhsTVQokOZ0zw==,
       }
 
   "@protobufjs/float@1.0.2":
@@ -2231,10 +2232,10 @@ packages:
         integrity: sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==,
       }
 
-  "@protobufjs/inquire@1.1.0":
+  "@protobufjs/inquire@1.1.2":
     resolution:
       {
-        integrity: sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q==,
+        integrity: sha512-pa0vFRuws4wkvaXKK1uXZMAwAX4/t8ANaJo45iw/oQHNQ9q5xUzwgFmVJGXiga2BeN+zpX7Vf9vmsiIa2J+MUw==,
       }
 
   "@protobufjs/path@1.1.2":
@@ -6392,10 +6393,10 @@ packages:
       }
     engines: { node: ">= 6" }
 
-  protobufjs@7.5.4:
+  protobufjs@7.6.1:
     resolution:
       {
-        integrity: sha512-CvexbZtbov6jW2eXAvLukXjXUW1TzFaivC46BpWc/3BpcCysb5Vffu+B3XHMm8lVEuy2Mm4XGex8hBSg1yapPg==,
+        integrity: sha512-4K0myLaWL5EteuSAro91EGFgcfVgxb64Jx+7oDAY6GOkXD4M69yuSEljNcInGVCA5sOPxmZ/EqDLj2x0Q0+Ygg==,
       }
     engines: { node: ">=12.0.0" }
 
@@ -8099,7 +8100,7 @@ snapshots:
     dependencies:
       lodash.camelcase: 4.3.0
       long: 5.3.2
-      protobufjs: 7.5.4
+      protobufjs: 7.6.1
       yargs: 17.7.2
 
   "@humanfs/core@0.19.1": {}
@@ -9166,18 +9167,17 @@ snapshots:
 
   "@protobufjs/base64@1.1.2": {}
 
-  "@protobufjs/codegen@2.0.4": {}
+  "@protobufjs/codegen@2.0.5": {}
 
-  "@protobufjs/eventemitter@1.1.0": {}
+  "@protobufjs/eventemitter@1.1.1": {}
 
-  "@protobufjs/fetch@1.1.0":
+  "@protobufjs/fetch@1.1.1":
     dependencies:
       "@protobufjs/aspromise": 1.1.2
-      "@protobufjs/inquire": 1.1.0
 
   "@protobufjs/float@1.0.2": {}
 
-  "@protobufjs/inquire@1.1.0": {}
+  "@protobufjs/inquire@1.1.2": {}
 
   "@protobufjs/path@1.1.2": {}
 
@@ -11949,15 +11949,15 @@ snapshots:
       kleur: 3.0.3
       sisteransi: 1.0.5
 
-  protobufjs@7.5.4:
+  protobufjs@7.6.1:
     dependencies:
       "@protobufjs/aspromise": 1.1.2
       "@protobufjs/base64": 1.1.2
-      "@protobufjs/codegen": 2.0.4
-      "@protobufjs/eventemitter": 1.1.0
-      "@protobufjs/fetch": 1.1.0
+      "@protobufjs/codegen": 2.0.5
+      "@protobufjs/eventemitter": 1.1.1
+      "@protobufjs/fetch": 1.1.1
       "@protobufjs/float": 1.0.2
-      "@protobufjs/inquire": 1.1.0
+      "@protobufjs/inquire": 1.1.2
       "@protobufjs/path": 1.1.2
       "@protobufjs/pool": 1.1.0
       "@protobufjs/utf8": 1.1.1


### PR DESCRIPTION
## Fixed

- **protobufjs 7.5.4** (×9 findings: CVE-2026-41242, CVE-2026-44288/9/90/91/92/93/94, CVE-2026-45740) — added `protobufjs@7: ^7.6.1` override. Comes in transitively via `@grpc/proto-loader` → OTel gRPC exporters; 7.5.6+ is the backported patch line (`pnpm audit` confirms). Type-check green.

## Skipped — auto-clears on next rebuild

The scanned image predates several already-merged overrides / direct-dep bumps. Rebuilding from this branch picks them up:

- `uuid` 8.0.0 → 13.0.1 (CVE-2026-41907, cross-major) — direct spec at `^11.1.1`; lockfile no longer carries an `uuid@8.x` copy.
- `picomatch` 4.0.3 → 4.0.4 (×2: CVE-2026-33671 HIGH, CVE-2026-33672 MEDIUM) — `picomatch@4` override at `^4.0.4`.
- `@protobufjs/utf8` 1.1.0 → 1.1.1 (CVE-2026-44288) — override at `^1.1.1`.
- `follow-redirects` 1.15.11 → 1.16.0 (GHSA-r4q5-vmmm-2653) — override at `^1.16.0`.
- `qs` 6.15.0 → 6.15.2 (CVE-2026-8723) — override at `^6.15.2`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Post-deploy projection

| Severity | Total findings | Addressed or auto-clears | Remaining |
| -------- | -------------- | ------------------------ | --------- |
| CRITICAL | 1              | 1                        | 0         |
| HIGH     | 7              | 7                        | 0         |
| MEDIUM   | 7              | 7                        | 0         |
