### PR TITLE
Add process-level crash guards for unhandled Mongo errors

### DIFF
--- a/packages/apps/proxy/src/index.ts
+++ b/packages/apps/proxy/src/index.ts
@@ -1,5 +1,6 @@
 import init from "./init";
 import { GrowthBookProxy, growthBookProxy } from "./app";
+import logger from "./services/logger";
 
 // Sample implementation for the GrowthBookProxy
 (async () => {
@@ -14,6 +15,16 @@ import { GrowthBookProxy, growthBookProxy } from "./app";
   });
   process.on("SIGINT", () => {
     console.info("SIGINT signal received: closing HTTP server");
+    onClose(server, proxy);
+  });
+  // A rejected promise with no .catch() (e.g. a transient Mongo/Redis error in
+  // a timer callback) crashes the whole process on modern Node unless handled
+  // here — log it and keep serving instead of taking the instance down.
+  process.on("unhandledRejection", (reason) => {
+    logger.error({ err: reason }, "Unhandled promise rejection");
+  });
+  process.on("uncaughtException", (err) => {
+    logger.error({ err }, "Uncaught exception: closing HTTP server");
     onClose(server, proxy);
   });
 })();

--- a/packages/apps/proxy/src/services/cache/MongoCache.ts
+++ b/packages/apps/proxy/src/services/cache/MongoCache.ts
@@ -86,7 +86,13 @@ export class MongoCache {
 
     // if cache miss from MemoryCache, fetch from Mongo
     if (!entry) {
-      const doc = await this.collection.findOne({ key });
+      let doc;
+      try {
+        doc = await this.collection.findOne({ key });
+      } catch (e) {
+        logger.error({ err: e }, "MongoCache: unable to fetch doc");
+        return undefined;
+      }
       if (!doc) {
         return undefined;
       }


### PR DESCRIPTION
## Summary
- Investigating a prod incident where 513 5xx requests spiked when one proxy instance crashed for ~60s after an uncaught `MongoServerSelectionError: ECONNREFUSED` killed the whole Node process.
- The actual polling loop that crashed lives in the private `growthbook-proxy-cloud` repo (companion PR there), but this open-source repo has the same class of gap, so hardening it here too:
  - `src/index.ts`: register `process.on("unhandledRejection"/"uncaughtException")` handlers that log and gracefully close the server instead of relying on Node's default (crash) behavior.
  - `src/services/cache/MongoCache.ts`: wrap `collection.findOne()` in try/catch so a transient Mongo error degrades to a cache miss instead of throwing out of `get()`.

## Test plan
- [x] `tsc --noEmit` passes
- [ ] Deploy to staging and confirm normal cache read/write still works