### PR TITLE
Switch runtime image to a distroless Docker Hardened Image

### DIFF
--- a/.github/workflows/deploy-proxy-custom-tag.yml
+++ b/.github/workflows/deploy-proxy-custom-tag.yml
@@ -29,6 +29,14 @@ jobs:
           username: ${{ secrets.DOCKER_HUB_USERNAME }}
           password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
 
+      # Required to pull the hardened base image (FROM dhi.io/...) in the Dockerfile.
+      - name: Login to Docker Hardened Images
+        uses: docker/login-action@v3
+        with:
+          registry: dhi.io
+          username: ${{ secrets.DOCKER_HUB_USERNAME }}
+          password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
+
       - name: Install Depot CLI
         uses: depot/setup-action@v1
 

--- a/.github/workflows/deploy-proxy.yml
+++ b/.github/workflows/deploy-proxy.yml
@@ -24,6 +24,14 @@ jobs:
           username: ${{ secrets.DOCKER_HUB_USERNAME }}
           password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
 
+      # Required to pull the hardened base image (FROM dhi.io/...) in the Dockerfile.
+      - name: Login to Docker Hardened Images
+        uses: docker/login-action@v3
+        with:
+          registry: dhi.io
+          username: ${{ secrets.DOCKER_HUB_USERNAME }}
+          password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
+
       - name: Install Depot CLI
         uses: depot/setup-action@v1
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,12 +27,12 @@ RUN \
   && pnpm deploy --filter=@growthbook/proxy --prod /app/pruned
 
 
-FROM node:22-slim
+# Ship on a distroless Docker Hardened Image: continuously patched, no shell, no
+# package manager, non-root uid 1000. ca-certificates ship in the base, so the
+# stock apt-upgrade + ca-certificates install is gone. Building from source
+# requires `docker login dhi.io` (free DHI Community tier); pulling needs no login.
+FROM dhi.io/node:22-debian12
 WORKDIR /app
-RUN apt-get update && apt-get -y upgrade && \
-  apt-get install -y ca-certificates && \
-  apt-get clean && \
-  rm -rf /var/lib/apt/lists/*
 COPY --from=0 /app/pruned/node_modules ./node_modules
 COPY --from=0 /app/pruned/package.json ./package.json
 COPY --from=0 /usr/local/src/app/packages/apps/proxy/dist ./dist
@@ -40,4 +40,7 @@ COPY --from=0 /usr/local/src/app/packages/apps/proxy/dist ./dist
 COPY buildinfo* ./buildinfo
 
 EXPOSE 3300
-CMD ["node_modules/.bin/pm2-runtime", "start", "dist/index.js"]
+# Launch pm2-runtime via node directly: the .bin shim is a #!/bin/sh script, and
+# pm2's own entry relies on #!/usr/bin/env node — neither can exec here, but pm2
+# itself is plain Node.
+CMD ["node", "node_modules/pm2/bin/pm2-runtime", "start", "dist/index.js"]


### PR DESCRIPTION
### Features and Changes

Swaps the runtime base from `node:22-slim` to `dhi.io/node:22-debian12` (no shell, no package manager, non-root uid 1000). `ca-certificates` ship in the base, so the apt-upgrade and ca-certificates install are gone. The build stage stays on `node:22-slim` since it never ships. Both deploy workflows gain a `dhi.io` login step so Depot can pull the private base.

Removes 24 CVEs, 4 of them critical:

- OS packages 13 -> 0 (3 critical): `perl` (10), `coreutils` (2), `util-linux` (1). None had a patched version available, so `apt-get -y upgrade` could never clear them.
- Base-bundled npm tree 11 -> 0 (1 critical): `tar`, `brace-expansion`, `sigstore`, `@sigstore/core`. This was the only one of our images still shipping `/usr/local/lib/node_modules/npm`, and since it publishes publicly as `growthbook/proxy`, those were reaching OSS consumers.

Debian packages drop 65 -> 16 and the image shrinks 316 -> 211 MB. The app's `node_modules` is untouched (405 packages, identical in both images) and its findings are unchanged.

:warning: The `CMD` had to change. pnpm generates `node_modules/.bin/pm2-runtime` as a `#!/bin/sh` wrapper, which can't exec without a shell, and pm2's own entry is `#!/usr/bin/env node` while the hardened base ships no `/usr/bin/env`. It now invokes pm2's real entry through `node` directly. Anything pinning the old `.bin` path — a `command:` override in a downstream compose or k8s manifest — needs updating.

### Testing

- [x] Built and ran both images, `curl /healthcheck` -> byte-identical `{"ok":true,"proxyVersion":"1.3.4",...}`
- [x] pm2 launches in no-daemon mode and forks the app on both
- [x] `inspector-sbomgen` + `aws inspector-scan` on both -> 24 CVEs removed
- [x] `perl` and `/usr/local/lib/node_modules/npm` present in the old image, absent in the new one
