### PR TITLE
Add yarn/pnpm compat shim so start:with-tracing still works on the DHI image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,9 +39,7 @@ COPY --from=0 /usr/local/src/app/packages/apps/proxy/dist ./dist
 # Directory with build info (git commit sha, build date)
 COPY buildinfo* ./buildinfo
 
-# yarn/pnpm compat shim so deploy configs overriding the Docker CMD with
-# `yarn start:with-tracing` or the README's documented `pnpm start:with-tracing`
-# keep working now that neither yarn nor pnpm are shipped in this image.
+# yarn/pnpm shim: neither is shipped here, but deploy configs still override the CMD with `<pm> start:with-tracing`.
 COPY --chmod=755 bin/start-shim /usr/local/bin/yarn
 COPY --chmod=755 bin/start-shim /usr/local/bin/pnpm
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -39,6 +39,12 @@ COPY --from=0 /usr/local/src/app/packages/apps/proxy/dist ./dist
 # Directory with build info (git commit sha, build date)
 COPY buildinfo* ./buildinfo
 
+# yarn/pnpm compat shim so deploy configs overriding the Docker CMD with
+# `yarn start:with-tracing` or the README's documented `pnpm start:with-tracing`
+# keep working now that neither yarn nor pnpm are shipped in this image.
+COPY --chmod=755 bin/start-shim /usr/local/bin/yarn
+COPY --chmod=755 bin/start-shim /usr/local/bin/pnpm
+
 EXPOSE 3300
 # Launch pm2-runtime via node directly: the .bin shim is a #!/bin/sh script, and
 # pm2's own entry relies on #!/usr/bin/env node — neither can exec here, but pm2

--- a/bin/start-shim
+++ b/bin/start-shim
@@ -1,0 +1,30 @@
+#!/usr/local/bin/node
+// yarn/pnpm compat shim for the shell-less distroless runtime image, which
+// ships neither (corepack/pnpm only exist in the discarded builder stage) -
+// lets deploy configs that override the Docker CMD with `yarn start:with-tracing`
+// or the documented `pnpm start:with-tracing` keep working. Ported from
+// growthbook's bin/yarn, rewritten as a node script since a bash shebang
+// can't exec on this image.
+const { spawnSync } = require("node:child_process");
+
+const PM2_RUNTIME = "node_modules/pm2/bin/pm2-runtime";
+
+const commands = {
+  start: [PM2_RUNTIME, "start", "dist/index.js"],
+  "start:with-tracing": [
+    PM2_RUNTIME,
+    "start",
+    "dist/index.js",
+    "--node-args=--require ./dist/tracing.js",
+  ],
+};
+
+const cmd = process.argv[2];
+const args = commands[cmd];
+if (!args) {
+  console.error(`start-shim: "${cmd}" is not supported on this image (only start / start:with-tracing are)`);
+  process.exit(1);
+}
+
+const result = spawnSync(process.execPath, args, { stdio: "inherit" });
+process.exit(result.status ?? 1);

--- a/bin/start-shim
+++ b/bin/start-shim
@@ -1,10 +1,5 @@
 #!/usr/local/bin/node
-// yarn/pnpm compat shim for the shell-less distroless runtime image, which
-// ships neither (corepack/pnpm only exist in the discarded builder stage) -
-// lets deploy configs that override the Docker CMD with `yarn start:with-tracing`
-// or the documented `pnpm start:with-tracing` keep working. Ported from
-// growthbook's bin/yarn, rewritten as a node script since a bash shebang
-// can't exec on this image.
+// yarn/pnpm shim for the shell-less distroless image, which ships neither - keeps `start:with-tracing` CMD overrides working.
 const { spawnSync } = require("node:child_process");
 
 const PM2_RUNTIME = "node_modules/pm2/bin/pm2-runtime";


### PR DESCRIPTION
### Features and Changes

The distroless final stage (#127) only installs corepack/pnpm in the discarded builder stage, so overriding the Docker CMD with `yarn start:with-tracing` (the pre-pnpm-migration pattern) or the README's documented `pnpm start:with-tracing` silently fails on the shipped image — neither binary exists there. Adds a node-based shim (`bin/start-shim`, installed at both `/usr/local/bin/yarn` and `/usr/local/bin/pnpm`) since a bash shebang can't exec on this shell-less base. It supports only `start` and `start:with-tracing`, driving `pm2-runtime` directly against the flattened `dist/` layout via `--node-args`.

### Testing

- [x] `yarn start` on the built image -> pm2-runtime launches `dist/index.js`, no tracing
- [x] `yarn start:with-tracing` -> pm2-runtime launches with OpenTelemetry auto-instrumentation initialized
- [x] `pnpm start:with-tracing` -> same as above (the README-documented path, also confirmed broken before this fix)
