### PR TITLE
Add .dockerignore to exclude node_modules/dist from build context

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+**/node_modules
+**/dist
+.git
+.eslintcache


### PR DESCRIPTION
### Features and Changes

Add a `.dockerignore` excluding `node_modules`, `dist`, `.git`, and `.eslintcache`. Without it, `COPY packages ./packages` pulls each package's local `node_modules`/`dist` from the host into the build context, shadowing the properly hoisted `node_modules` pnpm installs in the builder stage — this breaks `docker build` locally with TS2307 "Cannot find module" errors on any machine that already ran `pnpm install` for local dev. CI is unaffected since it builds from a clean checkout.

### Testing

Verified `docker build` succeeds from a checkout with local `pnpm install` artifacts present, and fails without the `.dockerignore`.
