### PR TITLE
Address security vulnerabilities (2026-08-14)

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,8 @@
       "@protobufjs/utf8@1": "^1.1.1",
       "protobufjs@7": "^7.6.5",
       "@grpc/grpc-js@1": "^1.14.4",
-      "@opentelemetry/core@2": "^2.8.0"
+      "@opentelemetry/core@2": "^2.8.0",
+      "@opentelemetry/propagator-jaeger@2": "^2.9.0"
     }
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -16,6 +16,7 @@ overrides:
   protobufjs@7: ^7.6.5
   '@grpc/grpc-js@1': ^1.14.4
   '@opentelemetry/core@2': ^2.8.0
+  '@opentelemetry/propagator-jaeger@2': ^2.9.0
 
 importers:
 
@@ -1400,8 +1401,8 @@ packages:
     peerDependencies:
       '@opentelemetry/api': '>=1.0.0 <1.10.0'
 
-  '@opentelemetry/propagator-jaeger@2.7.1':
-    resolution: {integrity: sha512-KMjVBHzP4N60bOzxja76M1F1hZZ43lGPga5ix+mkv9+kk1nx9SbkxSvJsMbuVUxdPQmsPTqGShmhN8ulrMOg6Q==}
+  '@opentelemetry/propagator-jaeger@2.10.0':
+    resolution: {integrity: sha512-yw/IX8DL470dSMZJoE82ScfYGp7JWZ/G8kFJo35ZILUVTB2jFPTOaioN+8s09pH0RHsWNhweVZb+ZnjJJpCChg==}
     engines: {node: ^18.19.0 || >=20.6.0}
     peerDependencies:
       '@opentelemetry/api': '>=1.0.0 <1.10.0'
@@ -5949,7 +5950,7 @@ snapshots:
       '@opentelemetry/api': 1.9.0
       '@opentelemetry/core': 2.8.0(@opentelemetry/api@1.9.0)
 
-  '@opentelemetry/propagator-jaeger@2.7.1(@opentelemetry/api@1.9.0)':
+  '@opentelemetry/propagator-jaeger@2.10.0(@opentelemetry/api@1.9.0)':
     dependencies:
       '@opentelemetry/api': 1.9.0
       '@opentelemetry/core': 2.8.0(@opentelemetry/api@1.9.0)
@@ -6032,7 +6033,7 @@ snapshots:
       '@opentelemetry/instrumentation': 0.218.0(@opentelemetry/api@1.9.0)
       '@opentelemetry/otlp-exporter-base': 0.218.0(@opentelemetry/api@1.9.0)
       '@opentelemetry/propagator-b3': 2.7.1(@opentelemetry/api@1.9.0)
-      '@opentelemetry/propagator-jaeger': 2.7.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/propagator-jaeger': 2.10.0(@opentelemetry/api@1.9.0)
       '@opentelemetry/resources': 2.7.1(@opentelemetry/api@1.9.0)
       '@opentelemetry/sdk-logs': 0.218.0(@opentelemetry/api@1.9.0)
       '@opentelemetry/sdk-metrics': 2.7.1(@opentelemetry/api@1.9.0)


### PR DESCRIPTION
### Features and Changes

Addresses the one Vanta/Inspector finding on the deployed `proxy` ECR image (which vendors this repo as compiled output): `@opentelemetry/propagator-jaeger` 2.7.1 → 2.9.0 (CVE-2026-59892). Added a `pnpm.overrides` entry — `@opentelemetry/sdk-node` hard-pins the vulnerable version transitively, and the parent is already at its latest release (0.218.0), so it doesn't move on its own.

Mirrors the same fix on `growthbook-proxy-cloud` — that repo builds the actual deployed image from vendored compiled JS, not this `package.json`/lockfile, so the fix needs to land in both places.

### Testing

- [x] `pnpm install` — resolves to 2.10.0
- [x] `pnpm type-check` — clean across all 7 workspace packages
